### PR TITLE
Render 404 template & handle Internal Server Error

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -55,7 +55,7 @@ api.use(router.allowedMethods());
 api.use(async (ctx, next) => {
   await next();
 
-  if ((ctx.status = 404)) {
+  if (ctx.status == 404) {
     views.render(ctx, {
       html: views.notFound,
       json: () => {

--- a/src/db/package.js
+++ b/src/db/package.js
@@ -365,7 +365,7 @@ LIMIT 1
     }
   );
 
-  return row.version;
+  return row?.version;
 }
 
 export async function getSummary(name, version) {
@@ -404,7 +404,7 @@ LIMIT 1
     }
   );
 
-  return row.readme;
+  return row?.readme;
 }
 
 export function getModuleList(packageName, version) {

--- a/src/routes/package.js
+++ b/src/routes/package.js
@@ -30,6 +30,7 @@ router.get("package-redirect", "/:author/:project", async (ctx, next) => {
 
   if (latestVersion == null) {
     ctx.status = 404;
+    await next();
     return;
   }
 
@@ -57,6 +58,7 @@ router.get(
 
     if (versions.length === 0) {
       ctx.status = 404;
+      await next();
       return;
     }
 
@@ -203,6 +205,7 @@ async function moduleOverview(ctx, next) {
   );
   if (moduleInfo == null) {
     ctx.status = 404;
+    await next();
     return;
   }
 
@@ -256,6 +259,7 @@ async function packageOverview(ctx, next) {
 
   if (readme == null) {
     ctx.status = 404;
+    await next();
     return;
   }
 


### PR DESCRIPTION
When a version is missing, the current route won't render the 404 template. 

![Screenshot 2023-07-24 at 22 22 04](https://github.com/gren-lang/package.gren-lang.org/assets/463904/6211bb73-403c-4f9b-bbe9-b3753e259cdc)


This PR include fixes for

* Fix to render the 404 template
* Fixes 5xx Internal Server Error

![Screenshot 2023-07-24 at 22 24 19](https://github.com/gren-lang/package.gren-lang.org/assets/463904/7032f1cc-9d36-4357-b3f0-58b4756488a8)

