### PR TITLE
fix: handle missing version gracefully

### DIFF
--- a/src/db/package.js
+++ b/src/db/package.js
@@ -384,7 +384,7 @@ LIMIT 1
     },
   );
 
-  return row.summary;
+  return row?.summary;
 }
 
 export async function getReadme(name, version) {


### PR DESCRIPTION
When a URL with missing/unknown version is requested `row` is undefined and caused an Internal Server Error

Now the exception is handled, and package site will render 404.

https://packages.gren-lang.org/package/gren-lang/browser/version/4.1.0/overview (Will give 500 Error)

#### BEFORE
![2024-03-06_22-39_1](https://github.com/gren-lang/package.gren-lang.org/assets/463904/0a76e3b0-38dd-46d1-a8e1-3b9f93921d36)

#### AFTER
![2024-03-06_22-39](https://github.com/gren-lang/package.gren-lang.org/assets/463904/a56d28ea-dc18-4ed5-9f61-32e740ceda79)
