### PR TITLE
fix(utils): fix the exception caused "_" char in the token name

### DIFF
--- a/src/utils/type_signature.js
+++ b/src/utils/type_signature.js
@@ -20,6 +20,8 @@ const SIG_SYNTAX = [
   CLOSE_BRACKETS,
 ];
 
+const allowedChars = new RegExp(/[a-z\._]/, "i");
+
 function lex(input) {
   let cursor = 0;
   let tokens = [];
@@ -30,7 +32,7 @@ function lex(input) {
     let cursorInc = 1;
     if (SIG_SYNTAX.includes(char)) {
       tokens = tokens.concat(char);
-    } else if (char.match(/[a-z\.]/i)) {
+    } else if (char.match(allowedChars)) {
       let innerCursor = 0;
       let innerChar = char;
       let str = "";
@@ -38,7 +40,7 @@ function lex(input) {
         str = str + innerChar;
         innerCursor = innerCursor + 1;
         innerChar = input[cursor + innerCursor];
-        if (!innerChar || !innerChar.match(/[a-z\.]/i)) {
+        if (!innerChar || !innerChar.match(allowedChars)) {
           break;
         }
       }

--- a/src/utils/type_signature.js
+++ b/src/utils/type_signature.js
@@ -56,7 +56,9 @@ function lex(input) {
     } else if (WHITESPACES.includes(char)) {
       // skip whitespaces
     } else {
-      throw new Error(`Invalid Character found "${char}" at ${cursor + 1}`);
+      throw new Error(
+        `Invalid Character found "${char}" at ${cursor + 1} ("${input}")`,
+      );
     }
     cursor = cursor + cursorInc;
   }

--- a/tests/utils/type_signature.test.js
+++ b/tests/utils/type_signature.test.js
@@ -148,4 +148,18 @@ describe("splitTypeSignature", () => {
 
     expect(splitTypeSignature(input)).toStrictEqual(result);
   });
+
+  test("token with '_' should not skip formatting", () => {
+    const input =
+      "{ host : String, port_ : Int, env : Environment, model : appModel}";
+    const result = [
+      "{ host : String",
+      ", port_ : Int",
+      ", env : Environment",
+      ", model : appModel",
+      "}",
+    ];
+
+    expect(splitTypeSignature(input)).toStrictEqual(result);
+  });
 });


### PR DESCRIPTION
Previously, the type signature like `{ host : String, port_ : Int, env : Environment, model : appModel}` caused exception and rendered the signature without splitting. 

### BEFORE

![2024-03-18_23-34](https://github.com/gren-lang/package.gren-lang.org/assets/463904/f03b0805-00bb-447e-91b4-c6cd1ac0ae52)


### AFTER

![image](https://github.com/gren-lang/package.gren-lang.org/assets/463904/3736ef06-719e-4023-b599-0bb2c6c80c81)
